### PR TITLE
mem tab aware of memory limit set via cgroup

### DIFF
--- a/views/mem.go
+++ b/views/mem.go
@@ -85,8 +85,13 @@ func (v *MEMView) Update(state *host.State) error {
 		v.swap.Data[0] = []float64{0.0}
 	}
 
-	v.rss.Title = fmt.Sprintf(" resident memory - %s of %s (%.1f%%) ", humanize.Bytes(uint64(used)),
-		humanize.Bytes(state.Memory.MemTotal*1024), usedPerc)
+	cgroupMemLimit := ""
+	if state.Process.MemoryLimit != -1 {
+		cgroupMemLimit = fmt.Sprintf("- cgroup memory limit: %s ", humanize.Bytes(uint64(state.Process.MemoryLimit)))
+	}
+
+	v.rss.Title = fmt.Sprintf(" resident memory - %s of %s (%.1f%%) %s", humanize.Bytes(uint64(used)),
+		humanize.Bytes(state.Memory.MemTotal*1024), usedPerc, cgroupMemLimit)
 	v.rss.Data[0] = append(v.rss.Data[0], usedPerc)
 
 	v.virt.Title = fmt.Sprintf(" virtual memory - %s ", humanize.Bytes(uint64(state.Process.Stat.VSize)))


### PR DESCRIPTION
This PR makes the tool aware of memory limit set via cgroup.. 
Example with a systemd service where memory limit has been enforced:
```bash
[angelopoerio@localhost uroboros]$ cat /proc/806/cgroup 
0::/system.slice/firewalld.service
[angelopoerio@localhost uroboros]$ 
[angelopoerio@localhost uroboros]$ cat /sys/fs/cgroup/system.slice/firewalld.service/memory.max
1073741824
[angelopoerio@localhost uroboros]$ 
```

This is how it appears in the memory tab:
![mem_tab](https://user-images.githubusercontent.com/350096/103483357-031dc980-4de7-11eb-8daf-241dbd9342d4.png)

The message is not shown if no limit is set for the process