### PR TITLE
fix: append zero values for avoiding panic of termui

### DIFF
--- a/views/cpu.go
+++ b/views/cpu.go
@@ -58,18 +58,21 @@ func (v* CPUView) Reset() {
 	v.tot.LineColors = []ui.Color{ui.ColorRed}
 	v.tot.MaxVal = 100.0
 	v.tot.Data = make([][]float64, 1)
+	v.tot.Data[0] = append(v.tot.Data[0], 0.0)
 
 	v.usr.Title = " user time "
 	v.usr.AxesColor = ui.ColorWhite
 	v.usr.LineColors = []ui.Color{ui.ColorYellow}
 	v.usr.MaxVal = 100.0
 	v.usr.Data = make([][]float64, 1)
+	v.usr.Data[0] = append(v.usr.Data[0], 0.0)
 
 	v.sys.Title = " kernel time "
 	v.sys.AxesColor = ui.ColorWhite
 	v.sys.LineColors = []ui.Color{ui.ColorWhite}
 	v.sys.MaxVal = 100.0
 	v.sys.Data = make([][]float64, 1)
+	v.sys.Data[0] = append(v.sys.Data[0], 0.0)
 
 	v.grid.Set(
 		ui.NewRow(1.0/3,


### PR DESCRIPTION
In my environment, the following command failed:

```
$ sudo _build/uro -pid 8257 -tabs "cpu"
panic: runtime error: index out of range [-3]

goroutine 1 [running]:
github.com/gizak/termui/v3/drawille.(*Canvas).SetPoint(...)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/drawille/drawille.go:36
github.com/gizak/termui/v3/drawille.(*Canvas).SetLine(0xc000341890, {0x4ad35e, 0x5}, {0xc0000c2179, 0x203000}, 0x1)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/drawille/drawille.go:43 +0x19c
github.com/gizak/termui/v3.(*Canvas).SetLine(...)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/canvas.go:26
github.com/gizak/termui/v3/widgets.(*Plot).renderBraille(0xc00012d540, 0xc0002c4810, {{0x4059000000000000, 0x5458e9}, {0x40c6d4, 0x57a9c0}}, 0x4059000000000000)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/widgets/plot.go:102 +0x5ea
github.com/gizak/termui/v3/widgets.(*Plot).Draw(0xc00012d540, 0x591ec0)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/widgets/plot.go:223 +0x114
github.com/gizak/termui/v3.(*Grid).Draw(0xc00007d790, 0x591860)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/grid.go:157 +0x17e
github.com/gizak/termui/v3.(*Grid).Draw(0xc0000c2000, 0xc0002c47e0)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/grid.go:157 +0x17e
github.com/gizak/termui/v3.Render({0xc000341bf0, 0x1, 0x0})
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/render.go:25 +0x173
main.renderUI()
	/home/anqou/workspace/uroboros/cmd/uro/ui.go:124 +0x890
main.uiLoop()
	/home/anqou/workspace/uroboros/cmd/uro/ui.go:172 +0x34a
main.main()
	/home/anqou/workspace/uroboros/cmd/uro/main.go:65 +0x266
```

This was filed as [a bug of termui](https://github.com/gizak/termui/issues/282), but it hasn't been responded to.

This patch of mine is a work-around for this problem.