### PR TITLE
fix: add support for multiple CPU cores

### DIFF
--- a/host/observe.go
+++ b/host/observe.go
@@ -51,5 +51,9 @@ func Observe(pid int) (*State, error) {
 		}
 	}
 
+	if state.CPUInfo, err = state.procfs.CPUInfo(); err != nil {
+		return nil, err
+	}
+
 	return state, err
 }

--- a/host/state.go
+++ b/host/state.go
@@ -19,4 +19,5 @@ type State struct {
 	Stat          procfs.Stat
 	Memory        procfs.Meminfo
 	Process       Process // process specific stats
+	CPUInfo       []procfs.CPUInfo
 }

--- a/views/cpu.go
+++ b/views/cpu.go
@@ -111,9 +111,10 @@ func (v *CPUView) Update(state *host.State) error {
 	total /= clockTicks
 	seconds := state.ObservedAt.Sub(v.history.At).Seconds()
 
-	cpuUser := (uDelta / clockTicks / seconds) * 100.0
-	cpuSys := (sDelta / clockTicks / seconds) * 100.0
-	cpuTot := (total / seconds) * 100.0
+	numCPUs := float64(len(state.CPUInfo))
+	cpuUser := (uDelta / clockTicks / seconds / numCPUs) * 100.0
+	cpuSys := (sDelta / clockTicks / seconds / numCPUs) * 100.0
+	cpuTot := (total / seconds / numCPUs) * 100.0
 
 	v.history.Set(state)
 


### PR DESCRIPTION
When the program being monitored uses multiple CPU cores (or threads), uroboros tries to use >100% values as CPU usages and causes panic of termui:

```
$ sudo _build/uro -pid 102849 -tabs "cpu"
panic: runtime error: index out of range [-3]

goroutine 1 [running]:
github.com/gizak/termui/v3/drawille.(*Canvas).SetPoint(...)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/drawille/drawille.go:36
github.com/gizak/termui/v3/drawille.(*Canvas).SetLine(0xc0000d1890, {0x4ad35e, 0x5}, {0xc00009deb9, 0x203000}, 0x1)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/drawille/drawille.go:43 +0x19c
github.com/gizak/termui/v3.(*Canvas).SetLine(...)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/canvas.go:26
github.com/gizak/termui/v3/widgets.(*Plot).renderBraille(0xc0000d7540, 0xc00009b830, {{0x4059000000000000, 0x5458e9}, {0x40c6d4, 0x57a9c0}}, 0x4059000000000000)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/widgets/plot.go:102 +0x5ea
github.com/gizak/termui/v3/widgets.(*Plot).Draw(0xc0000d7540, 0x591ec0)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/widgets/plot.go:223 +0x114
github.com/gizak/termui/v3.(*Grid).Draw(0xc00009d5f0, 0x591860)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/grid.go:157 +0x17e
github.com/gizak/termui/v3.(*Grid).Draw(0xc00009dd40, 0xc00009b800)
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/grid.go:157 +0x17e
github.com/gizak/termui/v3.Render({0xc0000d1bf0, 0x1, 0x0})
	/home/anqou/.go/pkg/mod/github.com/gizak/termui/v3@v3.1.0/render.go:25 +0x173
main.renderUI()
	/home/anqou/workspace/uroboros/cmd/uro/ui.go:124 +0x890
main.uiLoop()
	/home/anqou/workspace/uroboros/cmd/uro/ui.go:172 +0x34a
main.main()
	/home/anqou/workspace/uroboros/cmd/uro/main.go:65 +0x266
```

This PR fixes this problem, by dividing the values by the number of CPU cores.